### PR TITLE
T8161 - Melhorias no Módulo de Contrato de Serviço

### DIFF
--- a/web_one2many_kanban/models/web_one2many_kanban.py
+++ b/web_one2many_kanban/models/web_one2many_kanban.py
@@ -8,12 +8,39 @@ class WebFieldData(http.Controller):
 
     @http.route(['/web/fetch_x2m_data'], type='json', auth='public')
     def get_o2x_data(self, **kwargs):
+        """ - Obtém valores dos registros contidos em um campo relacional
+        one2many, para a formatação no kanban.
+        - Quando os campos de um registro são renderizados no kanban, os campos
+        one2many carregados para o kanban, tem uma lista com os IDS dos registros
+        relacionados. Essa função obtém os valores desses objetos relacionados.
+
+        - Nota Multidados: Foi adicionado a possibilidade de deixar explícito
+            os campos a carregar dos objetos relacionados. Essa melhoria resolve
+            um importante problema de performance. No XML basta informar no atributo
+            'options' do campo relacional, informando os campos a partir da chave
+            'fields'.
+            Exemplo: <field name="line_ids" options="{'fields': ['name', 'qty', 'value']}">
+
+        Returns:
+            list: lista dos valores dos registros relacionados a partir de um
+                campo relacional 'one2many'.
+        """
         o2x_records = kwargs.get('o2x_records')
         o2x_datas = []
+
+        # Cada record são os valores do campo renderizado para QWeb
         for record in o2x_records:
+            # Campos a ler os valores dos registros relacionados
+            o2x_fields = record.get('options', dict()).get('fields', [])
+
+            # Tabela que o campo relacional se relaciona
             o2x_model = record.get('relation', False)
+
+            # Ids dos registros relacionados
             o2x_ids = record.get('raw_value', False)
+
             if o2x_model:
+                # Leitura dos objetos relacionados pelo campo one2many
                 o2x_obj = request.env[o2x_model]
-                o2x_datas.append(o2x_obj.search_read([('id', 'in', o2x_ids)]))
+                o2x_datas.append(o2x_obj.search_read([('id', 'in', o2x_ids)], o2x_fields))
         return o2x_datas

--- a/web_one2many_kanban/static/src/js/web_one2many_kanban.js
+++ b/web_one2many_kanban/static/src/js/web_one2many_kanban.js
@@ -14,14 +14,16 @@ odoo.define('web_one2many_kanban.web_one2many_kanban', function (require) {
             _.each(this.fieldsInfo, function (field_info, field_nm) {
                 if (field_info.mode === 'list' || field_info.mode === 'kanban')
                 {
-                    o2x_field_names.push(field_nm);
+                    o2x_field_names.push({name: field_nm, options: field_info.options});
                 }
             });
             if ( o2x_field_names.length > 0) {
                 var o2x_records = [];
                 _.each(o2x_field_names, function (o2x_field_name) {
-                    var record = self.qweb_context.record[o2x_field_name];
+                    var record = self.qweb_context.record[o2x_field_name.name];
                     if (record.type === 'one2many') {
+                        // Adiciona opções do campo determinadas no XML
+                        record.options = o2x_field_name.options;
                         o2x_records.push(record);
                     }
                 });


### PR DESCRIPTION
# Descrição

- 'web_one2many_kanban': Especificar campos para leitura
  - Para melhorar a performance, e evitar lentidão, foi adicionado uma forma de passar os campos dos registros relacionados por um campo one2many, ao carregar ele no XML utilizando o atributo 'fields' nas options do campo: `options="{'fields': ['name', 'qty', 'value']}"`

# Informações adicionais

- [T8161](https://multi.multidados.tech/web?#id=8570&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [core](https://github.com/multidadosti-erp/odoo/pull/251)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1399)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/900)