### PR TITLE
T8719 - Adicionar no Kanban dos Orçamentos as Categorias dos Produtosseta

### DIFF
--- a/web_one2many_kanban/static/src/js/web_one2many_kanban.js
+++ b/web_one2many_kanban/static/src/js/web_one2many_kanban.js
@@ -45,6 +45,9 @@ odoo.define('web_one2many_kanban.web_one2many_kanban', function (require) {
                 self._replaceElement(self.qweb.render('kanban-box',
                     self.qweb_context));
                 self.$el.addClass('o_kanban_record').attr("tabindex", 0);
+                if (!self.group_readonly) {
+                    self.$el.addClass('draggable');
+                }
                 self.$el.attr('role', 'article');
                 self.$el.data('record', self);
                 if (self.$el.hasClass('oe_kanban_global_click') ||


### PR DESCRIPTION
# Descrição

- Adiciona regra para bloquear arrastar (drag) registros no kanban
  - Adiciona código para adicionar a classe `draggable` em registros que tenham `attrs readonly=False` no kanban.
  - No core foi adicionado para somente adicionar a funcionalidade de arrastar registros que possam alterar o campo.
    - Verificação feita pelos `attrs` do campo no xml

# Informações adicionais

- [T8719](https://multi.multidados.tech/web?#id=9128&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [core](https://github.com/multidadosti-erp/odoo/pull/296)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1585)