### PR TITLE
T9278 - Habilitar a visualização expandida em Dialog Forms

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -17,7 +17,8 @@ Dialog.include({
             self.$modal.find('.dialog_button_extend').on('click', self.proxy('_extending'));
             self.$modal.find('.dialog_button_restore').on('click', self.proxy('_restore'));
             return config.done(function(r) {
-                if (r.default_maximize) {
+                var default_maximize = (self.context || {}).default_maximize ? self.context.default_maximize : r.default_maximize;
+                if (default_maximize) {
                     self._extending();
                 } else {
                     self._restore();


### PR DESCRIPTION
# Descrição

- Verifica no contexto "default_maximize" para abrir dialogs expandidos
  - Permite expandir por padrão a visualização do Dialog, a partir do contexto `default_maximize`.

# Informações adicionais

- [T9278](https://multi.multidados.tech/web?#id=9687&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [core](https://github.com/multidadosti-erp/odoo/pull/359)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1780)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/1049)